### PR TITLE
Add support for primitive data types parameter

### DIFF
--- a/unittest/src/main/java/com/iconloop/score/test/Score.java
+++ b/unittest/src/main/java/com/iconloop/score/test/Score.java
@@ -72,6 +72,8 @@ public class Score extends TestBase {
                 paramClasses[i] = Integer.TYPE;
             } else if (type == Long.class) {
                 paramClasses[i] = Long.TYPE;
+            } else if (type == Short.class) {
+                paramClasses[i] = Short.TYPE;
             } else if (type == Boolean.class) {
                 paramClasses[i] = Boolean.TYPE;
             } else {

--- a/unittest/src/main/java/com/iconloop/score/test/Score.java
+++ b/unittest/src/main/java/com/iconloop/score/test/Score.java
@@ -67,15 +67,19 @@ public class Score extends TestBase {
         Class<?>[] paramClasses = new Class<?>[params.length];
         for (int i = 0; i < params.length; i++) {
             Class<?> type = params[i].getClass();
-            // Convert supported object types to native types
+            // Convert supported object types to primitive data types
             if (type == Integer.class) {
-                paramClasses[i] = Integer.TYPE;
+                paramClasses[i] = Integer.TYPE; // int
             } else if (type == Long.class) {
-                paramClasses[i] = Long.TYPE;
+                paramClasses[i] = Long.TYPE; // long
             } else if (type == Short.class) {
-                paramClasses[i] = Short.TYPE;
+                paramClasses[i] = Short.TYPE; // short
+            } else if (type == Character.class) {
+                paramClasses[i] = Character.TYPE; // char
+            } else if (type == Byte.class) {
+                paramClasses[i] = Byte.TYPE; // byte
             } else if (type == Boolean.class) {
-                paramClasses[i] = Boolean.TYPE;
+                paramClasses[i] = Boolean.TYPE; // boolean
             } else {
                 paramClasses[i] = type;
             }

--- a/unittest/src/main/java/com/iconloop/score/test/Score.java
+++ b/unittest/src/main/java/com/iconloop/score/test/Score.java
@@ -67,7 +67,14 @@ public class Score extends TestBase {
         Class<?>[] paramClasses = new Class<?>[params.length];
         for (int i = 0; i < params.length; i++) {
             Class<?> type = params[i].getClass();
-            paramClasses[i] = (type == Boolean.class) ? Boolean.TYPE : type;
+            // Convert supported object types to native types
+            if (type == Integer.class) {
+                paramClasses[i] = Integer.TYPE;
+            } else if (type == Boolean.class) {
+                paramClasses[i] = Boolean.TYPE;
+            } else {
+                paramClasses[i] = type;
+            }
         }
         try {
             Class<?> clazz = instance.getClass();

--- a/unittest/src/main/java/com/iconloop/score/test/Score.java
+++ b/unittest/src/main/java/com/iconloop/score/test/Score.java
@@ -70,6 +70,8 @@ public class Score extends TestBase {
             // Convert supported object types to native types
             if (type == Integer.class) {
                 paramClasses[i] = Integer.TYPE;
+            } else if (type == Long.class) {
+                paramClasses[i] = Long.TYPE;
             } else if (type == Boolean.class) {
                 paramClasses[i] = Boolean.TYPE;
             } else {


### PR DESCRIPTION
See https://github.com/icon-project/javaee-unittest/issues/2 for discussion around this issue.

I tested all these types from gochain v0.9.9-22 and Sejong. 
I identified the following types as valid parameters types: int, long, short, char, byte and boolean. Please let me know if I forgot some.