### PR TITLE
Update Context stack walking

### DIFF
--- a/unittest/src/main/java/com/iconloop/score/test/ServiceManager.java
+++ b/unittest/src/main/java/com/iconloop/score/test/ServiceManager.java
@@ -85,7 +85,7 @@ public class ServiceManager {
         return getCurrentFrame().to.getAddress();
     }
 
-    private Score getScoreFromClass(Class<?> caller) {
+    public Score getScoreFromClass(Class<?> caller) {
         var score = classScoreMap.get(caller);
         if (score == null) {
             for (Class<?> clazz: classScoreMap.keySet()) {

--- a/unittest/src/main/java/score/Context.java
+++ b/unittest/src/main/java/score/Context.java
@@ -115,13 +115,11 @@ public final class Context extends TestBase {
     }
 
     public static Object call(Address targetAddress, String method, Object... params) {
-        var caller = stackWalker.walk(Context::walkScore);
-        return sm.call(caller, BigInteger.ZERO, targetAddress, method, params);
+        return call(BigInteger.ZERO, targetAddress, method, params);
     }
 
     public static void transfer(Address targetAddress, BigInteger value) {
-        var caller = stackWalker.getCallerClass();
-        sm.call(caller, value, targetAddress, "fallback");
+        call(value, targetAddress, "fallback");
     }
 
     public static Address deploy(byte[] content, Object... params) {


### PR DESCRIPTION
The `stackWalker.getCallerClass()` will fail when `Context.call` is called in a method from a foreign class that is not a SCORE.

Example: 

```java
class HelloWorld {
  public HelloWorld  () {}

  @External
  public void callFoo (Address target) {
    HelperClass.foo(target);
  }
}

class HelperClass {
  public static void foo (Address target) {
    Context.call(target, "externalCall");
  }
}
```

When calling `foo` from `HelperClass`, the `getCallerClass` will return the `HelperClass` method, then it will fail later when calling `getScoreFromClass` as `HelperClass` is not a SCORE.

This PR walks the callstack and return the first item that doesn't throw on calling `getScoreFromClass`.