### PR TITLE
Prevent pushing a write frame on top of a readonly frame

### DIFF
--- a/unittest/src/main/java/com/iconloop/score/test/Score.java
+++ b/unittest/src/main/java/com/iconloop/score/test/Score.java
@@ -63,6 +63,15 @@ public class Score extends TestBase {
     }
 
     Object call(Account from, boolean readonly, BigInteger value, String method, Object... params) {
+        try {
+            if (!readonly && sm.getCurrentFrame().isReadonly()) {
+                // Cannot push a write frame on top of a read frame
+                readonly = true;
+            }
+        } catch (EmptyStackException e) {
+            // No frame pushed yet, pass
+        }
+
         sm.pushFrame(from, this.score, readonly, method, value);
         Class<?>[] paramClasses = new Class<?>[params.length];
         for (int i = 0; i < params.length; i++) {


### PR DESCRIPTION
Javaee-unittest silently modify the frame write permission even when it's on top of a readonly frame.

Consequently, such call won't fail whereas they should : 

```java
package com.iconloop.score.example;

import java.math.BigInteger;

import score.Context;
import score.VarDB;
import score.annotation.External;

public class HelloWorld {

    private final VarDB<BigInteger> myvar = Context.newVarDB("myvar", BigInteger.class);

    public HelloWorld() {}

    @External
    public void write () {
        myvar.set(BigInteger.ONE);
    }

    @External(readonly = true)
    public BigInteger entrypoint () {
        Context.call(Context.getAddress(), "write");
        return this.myvar.get();
    }
    
    @External(readonly = true)
    public BigInteger myvar () {
        return this.myvar.getOrDefault(BigInteger.ZERO);
    }
}
```

When calling `entrypoint` from a unit test using javaee-unittest, `myvar` will be modified, even though `entrypoint` is a readonly method. That's because `entrypoint` calls a write method `write` which overrides the readonly mode.

This PR force the readonly mode value when a frame is pushed on top of a readonly frame.