### PR TITLE
Support DB rollback on revert

### DIFF
--- a/unittest/src/main/java/com/iconloop/score/test/Score.java
+++ b/unittest/src/main/java/com/iconloop/score/test/Score.java
@@ -90,9 +90,11 @@ public class Score extends TestBase {
             return m.invoke(instance, params);
         } catch (NoSuchMethodException | IllegalAccessException e) {
             e.printStackTrace();
+            sm.revertCurrentFrame();
             throw new RuntimeException(e.getMessage());
         } catch (InvocationTargetException e) {
             e.printStackTrace();
+            sm.revertCurrentFrame();
             throw new AssertionError(e.getTargetException().getMessage());
         } finally {
             sm.popFrame();


### PR DESCRIPTION
Javaee-unittest currently don't support DB rollback on revert.
Consequently, whenever a revert happens, the DB is corrupted and cannot be trusted anymore in the current test.

It is particularly tedious in some SCORE methods that may catch a revert and keep running gracefully. In that case, javaee-unittest cannot test these methods.

This PR implements a DB rollback by using a cache Map that keeps track of new variables writes in the current frame using a simple Copy-On-Write strategy. That Map is wrote back to the DB if a revert is triggered.