### PR TITLE
Implement Context.call with type as a first argument

### DIFF
--- a/unittest/src/main/java/score/Context.java
+++ b/unittest/src/main/java/score/Context.java
@@ -95,7 +95,7 @@ public final class Context extends TestBase {
 
     public static<T> T call(Class<T> cls,
                             Address targetAddress, String method, Object... params) {
-        return null;
+        return cls.cast(call(targetAddress, method, params));
     }
 
     public static Object call(Address targetAddress, String method, Object... params) {


### PR DESCRIPTION
Such call isn't supported in the unittest framework : 

```java
var decimals = Context.call(BigInteger.class, irc2, "decimals")
```

This PR implements the `Context.call` method with a class type as a first argument.