### PR TITLE
Fix TypeConverter to return List object correctly

### DIFF
--- a/unittest/src/main/java/score/ServiceManagerImpl.java
+++ b/unittest/src/main/java/score/ServiceManagerImpl.java
@@ -608,7 +608,7 @@ class ServiceManagerImpl extends ServiceManager implements AnyDBImpl.ValueStore 
                 parsedParams[i] = null;
             } else {
                 try {
-                    parsedParams[i] = TypeConverter.cast(params[i], parameterClass);
+                    parsedParams[i] = TypeConverter.parameterize(params[i], parameterClass);
                 } catch (RuntimeException e) {
                     throw new IllegalArgumentException(
                             String.format("InvalidParameter(idx=%d,target=%s,source=%s)",

--- a/unittest/src/main/java/score/impl/TypeConverter.java
+++ b/unittest/src/main/java/score/impl/TypeConverter.java
@@ -32,8 +32,11 @@ import java.util.List;
 import java.util.Map;
 
 public class TypeConverter {
-    @SuppressWarnings("unchecked")
     public static Object normalize(Object so) {
+        return normalize(so, true);
+    }
+
+    private static Object normalize(Object so, boolean ret) {
         if (so==null) {
             return null;
         }
@@ -68,56 +71,57 @@ public class TypeConverter {
             for (int i = 0 ; i<o.length ; i++) {
                 no[i] = o[i];
             }
-            return no;
+            return ret ? List.of(no) : no;
         } else if (so instanceof char[]) {
             var o = (char[]) so;
             var no = new Object[o.length];
             for (int i = 0 ; i<o.length ; i++) {
                 no[i] = BigInteger.valueOf(o[i]);
             }
-            return no;
+            return ret ? List.of(no) : no;
         } else if (so instanceof short[]) {
             var o = (short[]) so;
             var no = new Object[o.length];
             for (int i = 0 ; i<o.length ; i++) {
                 no[i] = BigInteger.valueOf(o[i]);
             }
-            return no;
+            return ret ? List.of(no) : no;
         } else if (so instanceof int[]) {
             var o = (int[]) so;
             var no = new Object[o.length];
             for (int i = 0 ; i<o.length ; i++) {
                 no[i] = BigInteger.valueOf(o[i]);
             }
-            return no;
+            return ret ? List.of(no) : no;
         } else if (so instanceof long[]) {
             var o = (long[]) so;
             var no = new Object[o.length];
             for (int i = 0; i < o.length; i++) {
                 no[i] = BigInteger.valueOf(o[i]);
             }
-            return no;
+            return ret ? List.of(no) : no;
         } else if (so instanceof List) {
             var o = (List<?>)so;
             var no = new Object[o.size()];
             for (int i=0 ; i<no.length ; i++) {
-                no[i] = normalize(o.get(i));
+                no[i] = normalize(o.get(i), ret);
             }
-            return no;
+            return ret ? List.of(no) : no;
         } else if (so instanceof Map) {
+            @SuppressWarnings("unchecked")
             var o = (Map<String,Object>)so;
             var no = new LinkedHashMap<>();
             for (Map.Entry<String,Object> pair : o.entrySet()) {
-                no.put(pair.getKey(), normalize(pair.getValue()));
+                no.put(pair.getKey(), normalize(pair.getValue(), ret));
             }
             return no;
         } else if (clz.isArray()){
             var o = (Object[])so;
             var no = new Object[o.length];
             for (int i=0 ; i<o.length ; i++) {
-                no[i] = normalize(o[i]);
+                no[i] = normalize(o[i], ret);
             }
-            return no;
+            return ret ? List.of(no) : no;
         } else {
             var rProps = Property.getReadableProperties(so);
             if (rProps.isEmpty()) {
@@ -126,7 +130,7 @@ public class TypeConverter {
             var map = new java.util.TreeMap<>();
             for (var rp : rProps) {
                 try {
-                    map.put(rp.getName(), normalize(rp.get(so)));
+                    map.put(rp.getName(), normalize(rp.get(so), ret));
                 } catch (InvocationTargetException|IllegalAccessException e) {
                     throw new IllegalArgumentException(e);
                 }
@@ -198,7 +202,12 @@ public class TypeConverter {
     }
 
     @SuppressWarnings("unchecked")
-    public static Object specialize(Object so, Class<?> cls) {
+    public static<T> T parameterize(Object so, Class<T> cls) {
+        return (T)specialize(normalize(so, false), cls);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object specialize(Object so, Class<?> cls) {
         if (so == null ) {
             return null;
         }
@@ -272,7 +281,7 @@ public class TypeConverter {
     public static Object[] asEventObjects(Object[] objs) {
         Object[] normalized = new Object[objs.length];
         for (int i = 0; i < objs.length; i++) {
-            normalized[i] = normalize(objs[i]);
+            normalized[i] = normalize(objs[i], false);
         }
         return normalized;
     }

--- a/unittest/src/test/java/score/IntercallTest.java
+++ b/unittest/src/test/java/score/IntercallTest.java
@@ -26,6 +26,8 @@ import score.annotation.External;
 import score.annotation.Payable;
 
 import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -56,6 +58,36 @@ public class IntercallTest extends TestBase {
         @External(readonly = true)
         public BigInteger getStored() {
             return store.getOrDefault(BigInteger.ZERO);
+        }
+
+        @External(readonly=true)
+        public boolean[] getBoolArray(boolean[] v) {
+            return v;
+        }
+
+        @External(readonly=true)
+        public int[] getIntArray(int[] v) {
+            return v;
+        }
+
+        @External(readonly=true)
+        public String[] getStrArray(String[] v) {
+            return v;
+        }
+
+        @External(readonly=true)
+        public byte[][] getBytesArray(byte[][] v) {
+            return v;
+        }
+
+        @External(readonly=true)
+        public Address[] getAddressArray(Address[] v) {
+            return v;
+        }
+
+        @External(readonly=true)
+        public BigInteger[] getBigIntArray(BigInteger[] v) {
+            return v;
         }
     }
 
@@ -94,12 +126,180 @@ public class IntercallTest extends TestBase {
         public void transfer(Address target, BigInteger value) {
             Context.transfer(target, value);
         }
+
+        @External
+        public void callWithType(Address target, String type) {
+            switch (type) {
+                case "bool": {
+                    var ba = new boolean[]{false, true};
+                    var ret = (List<Object>) Context.call(target, "getBoolArray", (Object) ba);
+                    Context.require(ret.size() == ba.length);
+                    for (int i = 0; i < ba.length; i++) {
+                        var e = ret.get(i);
+                        if (e instanceof Boolean) {
+                            Context.require(((Boolean) e) == ba[i]);
+                        } else {
+                            Context.revert("not a boolean");
+                        }
+                    }
+                    break;
+                }
+                case "int": {
+                    var ia = new int[]{1, 2, 3};
+                    var ret = (List<Object>) Context.call(target, "getIntArray", (Object) ia);
+                    Context.require(ret.size() == ia.length);
+                    for (int i = 0; i < ia.length; i++) {
+                        var e = ret.get(i);
+                        if (e instanceof BigInteger) {
+                            Context.require(((BigInteger) e).intValue() == ia[i]);
+                        } else {
+                            Context.revert("not a BigInteger");
+                        }
+                    }
+                    break;
+                }
+                case "str": {
+                    var sa = new String[]{"a", "b", "c"};
+                    var ret = (List<Object>) Context.call(target, "getStrArray", (Object) sa);
+                    Context.require(ret.size() == sa.length);
+                    for (int i = 0; i < sa.length; i++) {
+                        var e = ret.get(i);
+                        if (e instanceof String) {
+                            Context.require(e.equals(sa[i]));
+                        } else {
+                            Context.revert("not a String");
+                        }
+                    }
+                    break;
+                }
+                case "bytes": {
+                    var ba = new byte[][]{new byte[]{0x1, 0x2}, new byte[]{0x3, 0x4}};
+                    var ret = (List<Object>) Context.call(target, "getBytesArray", (Object) ba);
+                    Context.require(ret.size() == ba.length);
+                    for (int i = 0; i < ba.length; i++) {
+                        var e = ret.get(i);
+                        if (e instanceof byte[]) {
+                            Context.require(Arrays.equals((byte[]) e, ba[i]));
+                        } else {
+                            Context.revert("not a byte[]");
+                        }
+                    }
+                    break;
+                }
+                case "Address": {
+                    var aa = new Address[]{
+                            Address.fromString("hx0000000000000000000000000000000000000001"),
+                            Address.fromString("hx0000000000000000000000000000000000000002")
+                    };
+                    var ret = (List<Object>) Context.call(target, "getAddressArray", (Object) aa);
+                    Context.require(ret.size() == aa.length);
+                    for (int i = 0; i < aa.length; i++) {
+                        var e = ret.get(i);
+                        if (e instanceof Address) {
+                            Context.require(e.equals(aa[i]));
+                        } else {
+                            Context.revert("not an Address");
+                        }
+                    }
+                    break;
+                }
+                case "bigInt": {
+                    var ba = new BigInteger[]{BigInteger.ZERO, BigInteger.ONE, BigInteger.TWO};
+                    var ret = (List<Object>) Context.call(target, "getBigIntArray", (Object) ba);
+                    Context.require(ret.size() == ba.length);
+                    for (int i = 0; i < ba.length; i++) {
+                        var e = ret.get(i);
+                        if (e instanceof BigInteger) {
+                            Context.require(e.equals(ba[i]));
+                        } else {
+                            Context.revert("not a BigInteger");
+                        }
+                    }
+                    break;
+                }
+                case "boolList": {
+                    var bl = List.of(false, true);
+                    var ret = (List<Object>) Context.call(target, "getBoolArray", (Object) bl);
+                    Context.require(ret.size() == bl.size());
+                    for (int i = 0; i < bl.size(); i++) {
+                        var e = ret.get(i);
+                        if (e instanceof Boolean) {
+                            Context.require(e == bl.get(i));
+                        } else {
+                            Context.revert("not a boolean");
+                        }
+                    }
+                    break;
+                }
+                case "intList": {
+                    var il = List.of(1, 2, 3);
+                    var ret = (List<Object>) Context.call(target, "getIntArray", (Object) il);
+                    Context.require(ret.size() == il.size());
+                    for (int i = 0; i < il.size(); i++) {
+                        var e = ret.get(i);
+                        if (e instanceof BigInteger) {
+                            Context.require(((BigInteger) e).intValue() == il.get(i));
+                        } else {
+                            Context.revert("not a BigInteger");
+                        }
+                    }
+                    break;
+                }
+                case "strList": {
+                    var sl = List.of("a", "b", "c");
+                    var ret = (List<Object>) Context.call(target, "getStrArray", (Object) sl);
+                    Context.require(ret.size() == sl.size());
+                    for (int i = 0; i < sl.size(); i++) {
+                        var e = ret.get(i);
+                        if (e instanceof String) {
+                            Context.require(e.equals(sl.get(i)));
+                        } else {
+                            Context.revert("not a String");
+                        }
+                    }
+                    break;
+                }
+                case "bytesList": {
+                    var bl = List.of(new byte[]{0x1, 0x2}, new byte[]{0x3, 0x4});
+                    var ret = (List<Object>) Context.call(target, "getBytesArray", (Object) bl);
+                    Context.require(ret.size() == bl.size());
+                    for (int i = 0; i < bl.size(); i++) {
+                        var e = ret.get(i);
+                        if (e instanceof byte[]) {
+                            Context.require(Arrays.equals((byte[]) e, bl.get(i)));
+                        } else {
+                            Context.revert("not a byte[]");
+                        }
+                    }
+                    break;
+                }
+                case "AddressList": {
+                    var aa = List.of(
+                            Address.fromString("hx0000000000000000000000000000000000000001"),
+                            Address.fromString("hx0000000000000000000000000000000000000002")
+                    );
+                    var ret = (List<Object>) Context.call(target, "getAddressArray", (Object) aa);
+                    Context.require(ret.size() == aa.size());
+                    for (int i = 0; i < aa.size(); i++) {
+                        var e = ret.get(i);
+                        if (e instanceof Address) {
+                            Context.require(e.equals(aa.get(i)));
+                        } else {
+                            Context.revert("not an Address");
+                        }
+                    }
+                    break;
+                }
+                default:
+                    Context.revert("Unknown type: " + type);
+            }
+        }
     }
 
     private static Score callee;
     private static Score callee2;
     private static Score caller;
-    private static Account user1 = sm.createAccount();
+    private static final Account user1 = sm.createAccount();
 
     @BeforeAll
     static void setup() throws Exception {
@@ -109,10 +309,21 @@ public class IntercallTest extends TestBase {
     }
 
     @Test
-    void testProxyCall() throws Exception {
+    void testProxyCall() {
         assertDoesNotThrow(() ->
                 caller.invoke(owner, "proxyCall", callee.getAddress())
         );
+    }
+
+    @Test
+    void testTypeConversion() {
+        String[] tests = {
+                "bool", "int", "str", "bytes", "Address", "bigInt",
+                "boolList", "intList", "strList", "bytesList", "AddressList"};
+        for (var type : tests) {
+            assertDoesNotThrow(() ->
+                    caller.invoke(owner, "callWithType", callee.getAddress(), type));
+        }
     }
 
     @Test

--- a/unittest/src/test/java/score/impl/TypeConverterTest.java
+++ b/unittest/src/test/java/score/impl/TypeConverterTest.java
@@ -5,6 +5,9 @@ import score.Address;
 import score.ObjectReader;
 import score.ObjectWriter;
 
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -46,6 +49,38 @@ class TypeConverterTest {
             var bs = TypeConverter.toBytes(tc);
             var real = TypeConverter.fromBytes(tc.getClass(), bs);
             assertEquals(tc, real);
+        }
+    }
+
+    @Test
+    void normalizeList() {
+        var cases = new Object[] {
+                List.of("a", "b", "c"),
+                List.of(BigInteger.ZERO, BigInteger.ONE),
+                List.of(new byte[]{0x1, 0x2}, new byte[]{0x3, 0x4}),
+                List.of(Map.of("a", BigInteger.ZERO), Map.of("b", BigInteger.ONE)),
+                List.of(Address.fromString("hx0800000000000000000000000000000000000000")),
+                new boolean[]{false, true},
+                new int[]{1, 2, 3},
+                new long[]{1L, 2L, 3L},
+                new String[]{"a", "b", "c"},
+                new BigInteger[]{BigInteger.ZERO, BigInteger.ONE},
+                new Address[]{Address.fromString("hx0800000000000000000000000000000000000000")}
+        };
+        for (var tc : cases) {
+            assertDoesNotThrow(() -> (List<Object>) TypeConverter.normalize(tc));
+        }
+    }
+
+    @Test
+    void normalizeMap() {
+        var cases = new Object[] {
+                Map.of("a", BigInteger.ZERO, "b", BigInteger.ONE),
+                Map.of("a", List.of("a", "b", "c")),
+                Map.of("a", List.of(Map.of("a", BigInteger.ZERO)))
+        };
+        for (var tc : cases) {
+            assertDoesNotThrow(() -> (Map<String, Object>) TypeConverter.normalize(tc));
         }
     }
 


### PR DESCRIPTION
Arrays should be returned as a List object in the intercall situation.